### PR TITLE
Add max_level to roster data creation

### DIFF
--- a/lib/CrewTools.ts
+++ b/lib/CrewTools.ts
@@ -36,8 +36,20 @@ export function calculateBuffConfig(): { [index: string]: IBuffStat } {
 	return buffConfig;
 }
 
-function rosterFromCrew(rosterEntry: any, crew: any): void {
+// WIP Interface for the Crew data.
+export interface ICrew {
+	level: number;
+	max_level: number;
+	rarity: number;
+	in_buy_back_state: boolean;
+	favorite: boolean;
+	id: number;
+	active_id: number;
+}
+
+function rosterFromCrew(rosterEntry: any, crew: any|ICrew): void {
 	rosterEntry.level = crew.level;
+	rosterEntry.max_level = crew.max_level;
 	rosterEntry.rarity = crew.rarity;
 	rosterEntry.buyback = crew.in_buy_back_state;
 	rosterEntry.favorite = crew.favorite;


### PR DESCRIPTION
This PR adds the `max_level` attribute to the roster data.

It also starts work on an interface `ICrew` for Crew objects.